### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,14 +6,14 @@
 
 - 测试版本4.1.2，4.2.2，4.4.2可用
 
-##2014-9-11修改
+## 2014-9-11修改
 
 - 修复设置高度`wrap_content`时显示不全的bug
 - 修复点击后，翻转过程中向下滑动出现的bug
 
 >注意：如果设置高度为`wrap_content`，为了保证动画视觉上的完整性，需要设置自身及所有关联窗口的`android:clipChildren`属性为false(代码中setClipChildren(false))。
 
-##使用
+## 使用
 
 
 	CardView cardView = (CardView) findViewById(R.id.cardView1);
@@ -28,7 +28,7 @@
 	});
 
 
-##问题
+## 问题
 
 - 测试2.3.2有严重bug（估计4.0版本之前都有此bug），不可用。
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
